### PR TITLE
Don't crash when a layer doesnt have extent set

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ tm.srs = {
   'WGS84': '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs',
   '900913': '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over'
 };
+tm.extent = {
+    'WGS84': [-180, -90, 180, 90],
+    '900913': [-20037508.34, -20037508.34, 20037508.34, 20037508.34]
+};
 
 // Return an object with sorted keys, ignoring case.
 tm.sortkeys = function(obj) {


### PR DESCRIPTION
Stack trace from crash:

```
/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/index.js:92
            memo[key] = tm.extent[id];
                                 ^
TypeError: Cannot read property '900913' of undefined
    at /home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/index.js:92:34
    at Function._.each._.forEach (/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:87:22)
    at _.(anonymous function) [as each] (/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:1178:39)
    at /home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/index.js:91:19
    at /home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:121:25
    at _.each._.forEach (/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:87:22)
    at Function._.reduce._.foldl._.inject (/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:116:5)
    at _.(anonymous function) [as reduce] (/home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/node_modules/underscore/underscore.js:1178:39)
    at /home/ubuntu/node_modules/tessera/node_modules/tilelive-tmsource/index.js:84:36
    at Array.map (native)
```
