### PR TITLE
Catch errors in TMSource constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,12 +201,12 @@ var TMSource = function(uri, callback) {
 
     try {
       self.info = yaml.load(data);
+
+      self.info.id = url.format(uri);
+      self.info = normalize(self.info);
     } catch (err) {
       return callback(err);
     }
-
-    self.info.id = url.format(uri);
-    self.info = normalize(self.info);
 
     return toXML(self.info, function(err, xml) {
       if (err) {


### PR DESCRIPTION
specifically, I found that `normalize()` would throw an error
if a data.yml file is pointed at a data source which does not exist.
Passing this error to the constructor callback allows the client application
to handle the error.
