### PR TITLE
Fix getInfo calling callback with 1 param instead of 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ var TMSource = function(uri, callback) {
 };
 
 TMSource.prototype.getInfo = function(callback) {
-  return setImmediate(callback, this.info);
+  return setImmediate(callback, null, this.info);
 };
 
 util.inherits(TMSource, Bridge);


### PR DESCRIPTION
This was causing tilelive-tmsource to not work with tilelive-merge.