### PR TITLE
Update tilelive-bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "tilelive-bridge": "^1.2.5",
+    "tilelive-bridge": "^2.3.1",
     "js-yaml": "^3.2.5",
     "carto": "^0.14.1",
     "underscore": "^1.7.0",
     "mapnik-reference": "8.x"
   },
   "peerDependencies": {
-    "mapnik": ">=1.4.2"
+    "mapnik": "~3.5.0"
   }
 }


### PR DESCRIPTION
Fixes #9. I have tested it and seems to work at least for generating regular vector tiles (which meet the MVT v2 specification).